### PR TITLE
Remove logging in init()

### DIFF
--- a/src/Colorit.php
+++ b/src/Colorit.php
@@ -88,8 +88,6 @@ class Colorit extends Plugin
         $this->_registerWidgets();
         $this->_registerVariables();
         $this->_registerElementTypes();
-
-        Craft::info(Craft::t('colorit', '{name} plugin loaded', ['name' => $this->name]), __METHOD__);
     }
 
     public function beforeInstall(): bool


### PR DESCRIPTION
I'd like to remove this `Craft::info()` call from init() since it creates a lot of noise in log files.